### PR TITLE
Allow a no_release label to skip enforce

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,11 +12,11 @@ If the check fails, an error will be printed and if the parameter: `enforce` is 
 
 ### `enforce`
 
-**Optional** If this is set tu true, this will cause the action to fail with an error if the version is not specified correctly.
+**Optional** If this is set to true, this will cause the action to fail with an error if the version is not specified correctly.
 
 ### `allow_no_release`
 
-**Optional** Allow a `no release`, `no_release` or `no-release` label to allow the function to not fail with enforce even if no version is present. Care needs to be taken when using this as enforce will NOT preven the function from returning an empy version type string. This is intended for use in places where a release label of some kind is required and a PR that should NOT do a release is explicity labelled.
+**Optional** Allow a `no release`, `norelease`, `no_release` or `no-release` label to allow the function to not fail with enforce even if no version is present. Care needs to be taken when using this as enforce will NOT prevent the function from returning an empty version type string. This is intended for use in places where a release label of some kind is required and a PR that should NOT do a release is explicity labelled.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -14,6 +14,10 @@ If the check fails, an error will be printed and if the parameter: `enforce` is 
 
 **Optional** If this is set tu true, this will cause the action to fail with an error if the version is not specified correctly.
 
+### `allow_no_release`
+
+**Optional** Allow a `no release`, `no_release` or `no-release` label to allow the function to not fail with enforce even if no version is present. Care needs to be taken when using this as enforce will NOT preven the function from returning an empy version type string. This is intended for use in places where a release label of some kind is required and a PR that should NOT do a release is explicity labelled.
+
 ## Outputs
 
 ### `VERSION_UPPER` 

--- a/action.yml
+++ b/action.yml
@@ -5,6 +5,10 @@ inputs:
     description: 'If this is set to true, the action will fail if a version type is not specifed.'
     required: false
     default: false
+  allow_no_release:
+    description: 'If this is set, then no_release tag is considered an acceptable "release" label.'
+    required: false
+    default: false
 outputs:
   VERSION_UPPER:
     description: 'Version type in uppercase'

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -59,6 +59,18 @@ describe("check-versioning-action", () => {
       expect(core.setOutput).toHaveBeenCalledWith("VERSION_LOWER", "patch");
     });
 
+    it("Fails if both version and 'no release' are set", () => {
+      github.context.payload = {
+        pull_request: {
+          number: 1,
+          labels: [createLabel("patch"), createLabel("no_release")]
+        }
+      };
+
+      action();
+      expect(core.setFailed).toHaveBeenCalled();
+    });
+
     it("sets empty version when there are multiple labels", () => {
       github.context.payload = {
         pull_request: {
@@ -137,6 +149,34 @@ describe("check-versioning-action", () => {
 
         (core.getInput as jest.Mock).mockReturnValueOnce("true");
         (core.getInput as jest.Mock).mockReturnValueOnce("false");
+        action();
+        expect(core.setFailed).toHaveBeenCalled();
+      });
+
+      it("Fails if both version and no release set without allowing label", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: [createLabel("minor"), createLabel("no_release")]
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("false");
+        action();
+        expect(core.setFailed).toHaveBeenCalled();
+      });
+
+      it("Fails if both version and no release set with allowing label", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: [createLabel("minor"), createLabel("no_release")]
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
         action();
         expect(core.setFailed).toHaveBeenCalled();
       });

--- a/src/action.spec.ts
+++ b/src/action.spec.ts
@@ -107,7 +107,36 @@ describe("check-versioning-action", () => {
           }
         };
 
-        (core.getInput as jest.Mock).mockReturnValue("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("false");
+        action();
+        expect(core.setFailed).toHaveBeenCalled();
+      });
+
+      it("sets failed message when there are no labels, even if the no-release option is set.", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: []
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        action();
+        expect(core.setFailed).toHaveBeenCalled();
+      });
+
+      it("sets failed message when there are no labels, even if the no-release label is set.", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: [createLabel("no_release")]
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("false");
         action();
         expect(core.setFailed).toHaveBeenCalled();
       });
@@ -120,9 +149,40 @@ describe("check-versioning-action", () => {
           }
         };
 
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
         action();
         expect(core.setOutput).toHaveBeenCalledWith("VERSION_UPPER", "MINOR");
         expect(core.setOutput).toHaveBeenCalledWith("VERSION_LOWER", "minor");
+      });
+
+      it("Accepts no release when properly configured", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: [createLabel("no_release")]
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        action();
+        expect(core.setOutput).toHaveBeenCalledWith("VERSION_UPPER", "");
+        expect(core.setOutput).toHaveBeenCalledWith("VERSION_LOWER", "");
+      });
+
+      it("Accepts no release when properly configured 2", () => {
+        github.context.payload = {
+          pull_request: {
+            number: 1,
+            labels: [createLabel("no release")]
+          }
+        };
+
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        (core.getInput as jest.Mock).mockReturnValueOnce("true");
+        action();
+        expect(core.setOutput).toHaveBeenCalledWith("VERSION_UPPER", "");
+        expect(core.setOutput).toHaveBeenCalledWith("VERSION_LOWER", "");
       });
 
     });

--- a/src/action.ts
+++ b/src/action.ts
@@ -18,8 +18,7 @@ function fetchAndFilterLabels():string[] {
 
 function noReleaseSet():boolean {
   const labels = (github.context.payload.pull_request.labels as Label[])
-    .map(label => label.name)
-    .filter(label => NoReleaseLabels.includes(label.toLowerCase()));
+    .filter(label => NoReleaseLabels.includes(label.name.toLowerCase()));
 
   return (labels.length > 0)
 }

--- a/src/action.ts
+++ b/src/action.ts
@@ -2,7 +2,7 @@ import * as core from "@actions/core";
 import * as github from "@actions/github";
 
 const Versions = ["major", "minor", "patch"];
-const NoReleaseLabels = ["no release", "no_release", "no-release"];
+const NoReleaseLabels = ["no release", "norelease", "no_release", "no-release"];
 
 type Label = {
   name: string;


### PR DESCRIPTION
Allow the enforce mechanic to optionally be skipped with a 'no release' label. This is intended for projects where developers MUST specify a version for a build to succeed.