### PR TITLE
Fix release workflow

### DIFF
--- a/.github/templates/release.yml.erb
+++ b/.github/templates/release.yml.erb
@@ -7,8 +7,6 @@ on:
 jobs:
   @import ./jobs/build
 
-  @import ./jobs/test
-
   release:
     runs-on: <%= ubuntu_version %>
     name: "Build and release action"

--- a/.github/workflows/release.generated.yml
+++ b/.github/workflows/release.generated.yml
@@ -35,21 +35,6 @@ jobs:
         npm run build
         npm run package
 
-  test:
-    runs-on: ubuntu-18.04
-    steps:
-    - uses: actions/checkout@v2
-    - name: "Build action for test"
-      run: |
-        npm install
-        npm run all
-        git clean -fXd
-    - name: Test executing the action
-      uses: ./
-      with:
-        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        enforce: false
-
   release:
     runs-on: ubuntu-18.04
     name: "Build and release action"


### PR DESCRIPTION
Executing the action on master push workflow (i.e. release) makes no sense because there's no PR to check the version of